### PR TITLE
Bump Version - 1.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
     multi_xml (0.6.0)
-    rake (10.5.0)
+    rake (12.3.3)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -36,7 +36,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.2, >= 2.2.3)
-  rake (~> 10.0)
+  rake (~> 12.3, >= 12.3.3)
   vpos!
 
 BUNDLED WITH

--- a/lib/vpos/version.rb
+++ b/lib/vpos/version.rb
@@ -1,3 +1,3 @@
 module VposModule
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/vpos.gemspec
+++ b/vpos.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", '~> 2.2', '>= 2.2.3'
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'
   spec.add_dependency "httparty", "~> 0.18.1"
   spec.add_dependency "rspec", '~> 3.9', ">= 3.9.0"
 end


### PR DESCRIPTION
This pr updates the version to 1.0.2 because of vulnerability found at the dependency 10.3 that as to be updated to version 12.3.3 mentioned at CVE-2020-8130